### PR TITLE
Hotfix safari

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,9 +73,19 @@ function decodeArrayBuffer(audioCtx, arrayBuffer) {
 async function getFileAudioBuffer(file, audioCtx, options = {}) {
   /* Copyright (c) 2019, Timothée 'Tim' Pillard, @ziir @tpillard - ISC */
 
-  const { concurrency = CONCURRENCY } = options;
+  const { native = false, concurrency = CONCURRENCY } = options;
 
   const arrayBuffer = await getArrayBuffer(file);
+
+  if (native) {
+    return decodeArrayBuffer(audioCtx, arrayBuffer);
+  }
+
+  const safari = !!window.webkitAudioContext;
+  if (safari) {
+    return getFileAudioBuffer(file, audioCtx, { native: true });
+  }
+
   const view = new DataView(arrayBuffer);
 
   const tags = parser.readTags(view);

--- a/src/index.js
+++ b/src/index.js
@@ -132,9 +132,10 @@ async function getFileAudioBuffer(file, audioCtx, options = {}) {
   );
 
   for (let j = 0; j < numberOfChannels; j++) {
+    const channelData = audioBuffer.getChannelData(j);
     let offset = 0;
     for (let i = 0; i < audioBuffers.length; i++) {
-      audioBuffer.copyToChannel(audioBuffers[i].getChannelData(j), j, offset);
+      channelData.set(audioBuffers[i].getChannelData(j), offset);
       offset += audioBuffers[i].length;
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -7,11 +7,26 @@ async function run() {
     return audioCtx.decodeAudioData(arrayBuffer);
   });
 
+  await test(`decode-audio-data-fast - native`, () => {
+    const audioCtx = new window.AudioContext();
+    return DADF.getFileAudioBuffer(file, audioCtx, { native: true });
+  });
+
+  await test(`decode-audio-data-fast - webkitAudioContext -> Safari -> native`, async () => {
+    window.webkitAudioContext = {};
+
+    const audioCtx = new window.AudioContext();
+    const buffer = await DADF.getFileAudioBuffer(file, audioCtx);
+
+    delete window.webkitAudioContext;
+    return buffer;
+  });
+
   const concurrencies = [undefined, 4];
   for (concurrency of concurrencies) {
     await test(`decode-audio-data-fast - concurrency = ${
       concurrency || 'auto'
-    }`, async () => {
+    }`, () => {
       const audioCtx = new window.AudioContext();
       return DADF.getFileAudioBuffer(file, audioCtx, { concurrency });
     });


### PR DESCRIPTION
- Add `native` option
- Use native audio decoding for Safari (tested via the presence of `window.webkitAudioData`.

This should suffice for having `decode-audio-data-fast` ~work on most modern browsers, even if it does in a degraded mode for Safari for now. 